### PR TITLE
Update navigation and add placeholders

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -21,36 +21,33 @@ const altLink = locale === 'ja' ? '/en/' : '/'
       <a href={`${prefix}/`}>{locale === 'ja' ? 'ホーム' : 'Home'}</a>
     </li>
     <li class="menu-item">
-      <a href={`${prefix}/blog/`}>{locale === 'ja' ? 'ブログ' : 'Blog'}</a>
+      <a href={`${prefix}/services`}>{locale === 'ja' ? 'サービス' : 'Services'}</a>
     </li>
     <li class="menu-item">
-      <a href={`${prefix}/portfolio/`}>{locale === 'ja' ? 'ポートフォリオ' : 'Portfolio'}</a>
+      <a href={`${prefix}/pricing`}>{locale === 'ja' ? '料金' : 'Pricing'}</a>
     </li>
     <li class="menu-item has-dropdown">
       <button aria-haspopup="true" aria-expanded="false">
-        {locale === 'ja' ? 'テーマ機能' : 'Theme features'}
+        {locale === 'ja' ? '概要' : 'About'}
         <Icon name="lucide:chevron-down" size="32" />
       </button>
       <ul class="dropdown-menu">
         <li class="submenu-item">
-          <a href={`${prefix}/accessibility-statement`}>{locale === 'ja' ? 'アクセシビリティ声明' : 'Accessibility statement'}</a>
+          <a href={`${prefix}/about`}>{locale === 'ja' ? '概要' : 'About'}</a>
         </li>
         <li class="submenu-item">
-          <a href={`${prefix}/accessible-components`}>{locale === 'ja' ? 'アクセシブルコンポーネント' : 'Accessible components'}</a>
+          <a href={`${prefix}/samples`}>{locale === 'ja' ? 'サンプル' : 'Samples'}</a>
         </li>
         <li class="submenu-item">
-          <a href={`${prefix}/color-contrast-checker`}>{locale === 'ja' ? 'カラーコントラストチェッカー' : 'Color contrast checker'}</a>
+          <a href={`${prefix}/testimonials`}>{locale === 'ja' ? 'お客様の声' : 'Testimonials'}</a>
         </li>
         <li class="submenu-item">
-          <a href={`${prefix}/markdown-page/`}>{locale === 'ja' ? 'Markdownページ' : 'Markdown page'}</a>
-        </li>
-        <li class="submenu-item">
-          <a href={`${prefix}/mdx-page/`}>{locale === 'ja' ? 'MDXページ' : 'MDX page'}</a>
-        </li>
-        <li class="submenu-item">
-          <a href={`${prefix}/404-page`}>404 page</a>
+          <a href={`${prefix}/faq`}>{locale === 'ja' ? 'よくある質問' : 'FAQ'}</a>
         </li>
       </ul>
+    </li>
+    <li class="menu-item">
+      <a href={`${prefix}/contact`}>{locale === 'ja' ? 'お問い合わせ' : 'Contact'}</a>
     </li>
     <li class="menu-item">
       <a class="locale-switch" href={altLink}>{locale === 'ja' ? 'English' : '日本語'}</a>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,12 @@
+---
+import DefaultLayout from '@layouts/DefaultLayout.astro'
+---
+
+<DefaultLayout title="当社について">
+  <section class="my-12">
+    <div class="container space-content">
+      <h1>当社について</h1>
+      <p class="text-2xl">こちらは当社情報ページのプレースホルダーです。</p>
+    </div>
+  </section>
+</DefaultLayout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,12 @@
+---
+import DefaultLayout from '@layouts/DefaultLayout.astro'
+---
+
+<DefaultLayout title="お問い合わせ">
+  <section class="my-12">
+    <div class="container space-content">
+      <h1>お問い合わせ</h1>
+      <p class="text-2xl">こちらはお問い合わせページのプレースホルダーです。</p>
+    </div>
+  </section>
+</DefaultLayout>

--- a/src/pages/en/about.astro
+++ b/src/pages/en/about.astro
@@ -1,0 +1,12 @@
+---
+import DefaultLayout from '@layouts/DefaultLayout.astro'
+---
+
+<DefaultLayout title="About">
+  <section class="my-12">
+    <div class="container space-content">
+      <h1>About</h1>
+      <p class="text-2xl">This is a placeholder for the About page.</p>
+    </div>
+  </section>
+</DefaultLayout>

--- a/src/pages/en/contact.astro
+++ b/src/pages/en/contact.astro
@@ -1,0 +1,12 @@
+---
+import DefaultLayout from '@layouts/DefaultLayout.astro'
+---
+
+<DefaultLayout title="Contact">
+  <section class="my-12">
+    <div class="container space-content">
+      <h1>Contact</h1>
+      <p class="text-2xl">This is a placeholder for the Contact page.</p>
+    </div>
+  </section>
+</DefaultLayout>

--- a/src/pages/en/faq.astro
+++ b/src/pages/en/faq.astro
@@ -1,0 +1,12 @@
+---
+import DefaultLayout from '@layouts/DefaultLayout.astro'
+---
+
+<DefaultLayout title="FAQ">
+  <section class="my-12">
+    <div class="container space-content">
+      <h1>FAQ</h1>
+      <p class="text-2xl">This is a placeholder for the FAQ page.</p>
+    </div>
+  </section>
+</DefaultLayout>

--- a/src/pages/en/pricing.astro
+++ b/src/pages/en/pricing.astro
@@ -1,0 +1,12 @@
+---
+import DefaultLayout from '@layouts/DefaultLayout.astro'
+---
+
+<DefaultLayout title="Pricing">
+  <section class="my-12">
+    <div class="container space-content">
+      <h1>Pricing</h1>
+      <p class="text-2xl">This is a placeholder for the Pricing page.</p>
+    </div>
+  </section>
+</DefaultLayout>

--- a/src/pages/en/samples.astro
+++ b/src/pages/en/samples.astro
@@ -1,0 +1,12 @@
+---
+import DefaultLayout from '@layouts/DefaultLayout.astro'
+---
+
+<DefaultLayout title="Samples">
+  <section class="my-12">
+    <div class="container space-content">
+      <h1>Samples</h1>
+      <p class="text-2xl">This is a placeholder for the Samples page.</p>
+    </div>
+  </section>
+</DefaultLayout>

--- a/src/pages/en/services.astro
+++ b/src/pages/en/services.astro
@@ -1,0 +1,12 @@
+---
+import DefaultLayout from '@layouts/DefaultLayout.astro'
+---
+
+<DefaultLayout title="Services">
+  <section class="my-12">
+    <div class="container space-content">
+      <h1>Services</h1>
+      <p class="text-2xl">This is a placeholder for the Services page.</p>
+    </div>
+  </section>
+</DefaultLayout>

--- a/src/pages/en/testimonials.astro
+++ b/src/pages/en/testimonials.astro
@@ -1,0 +1,12 @@
+---
+import DefaultLayout from '@layouts/DefaultLayout.astro'
+---
+
+<DefaultLayout title="Testimonials">
+  <section class="my-12">
+    <div class="container space-content">
+      <h1>Testimonials</h1>
+      <p class="text-2xl">This is a placeholder for the Testimonials page.</p>
+    </div>
+  </section>
+</DefaultLayout>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -1,0 +1,12 @@
+---
+import DefaultLayout from '@layouts/DefaultLayout.astro'
+---
+
+<DefaultLayout title="よくある質問">
+  <section class="my-12">
+    <div class="container space-content">
+      <h1>よくある質問</h1>
+      <p class="text-2xl">こちらはFAQページのプレースホルダーです。</p>
+    </div>
+  </section>
+</DefaultLayout>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -1,0 +1,12 @@
+---
+import DefaultLayout from '@layouts/DefaultLayout.astro'
+---
+
+<DefaultLayout title="料金">
+  <section class="my-12">
+    <div class="container space-content">
+      <h1>料金</h1>
+      <p class="text-2xl">こちらは料金ページのプレースホルダーです。</p>
+    </div>
+  </section>
+</DefaultLayout>

--- a/src/pages/samples.astro
+++ b/src/pages/samples.astro
@@ -1,0 +1,12 @@
+---
+import DefaultLayout from '@layouts/DefaultLayout.astro'
+---
+
+<DefaultLayout title="サンプル">
+  <section class="my-12">
+    <div class="container space-content">
+      <h1>サンプル</h1>
+      <p class="text-2xl">こちらはサンプルページのプレースホルダーです。</p>
+    </div>
+  </section>
+</DefaultLayout>

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -1,0 +1,12 @@
+---
+import DefaultLayout from '@layouts/DefaultLayout.astro'
+---
+
+<DefaultLayout title="サービス">
+  <section class="my-12">
+    <div class="container space-content">
+      <h1>サービス</h1>
+      <p class="text-2xl">こちらはサービスページのプレースホルダーです。</p>
+    </div>
+  </section>
+</DefaultLayout>

--- a/src/pages/testimonials.astro
+++ b/src/pages/testimonials.astro
@@ -1,0 +1,12 @@
+---
+import DefaultLayout from '@layouts/DefaultLayout.astro'
+---
+
+<DefaultLayout title="お客様の声">
+  <section class="my-12">
+    <div class="container space-content">
+      <h1>お客様の声</h1>
+      <p class="text-2xl">こちらはお客様の声ページのプレースホルダーです。</p>
+    </div>
+  </section>
+</DefaultLayout>


### PR DESCRIPTION
## Summary
- rework header nav menu for new sections
- add placeholder pages in Japanese and English

## Testing
- `npm run build` *(fails: Failed to call getStaticPaths for blog posts)*

------
https://chatgpt.com/codex/tasks/task_e_684585682044832c9544080505d1e354