### PR TITLE
Fix: Apply underline hover effect to language switcher

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -280,9 +280,9 @@ import Logo from './Logo.astro'
           align-content: center;
         }
 
-        a:hover:not(.locale-switch),
-        a:focus-visible:not(.locale-switch),
-        .is-active:not(.locale-switch),
+        a:hover,
+        a:focus-visible,
+        .is-active,
         button[aria-expanded='true'],
         .has-dropdown > button:hover,
         .has-dropdown > button:focus-visible {
@@ -313,13 +313,6 @@ import Logo from './Logo.astro'
           }
         }
 
-        .locale-switch {
-          text-decoration: none;
-
-          &:where(:hover, :focus-visible) {
-            text-decoration: none;
-          }
-        }
       }
     }
 


### PR DESCRIPTION
The language switcher link was not getting the same underline hover effect as other header menu links.

This commit modifies the SCSS rules in `src/components/Navigation.astro` to ensure the language switcher link also receives the underline hover effect.

- Removed `:not(.locale-switch)` from the SCSS rule that defines the hover effect for menu links.
- Removed the specific SCSS rule for `.locale-switch` that explicitly set `text-decoration: none;`.